### PR TITLE
Fix admin panel and chat issues

### DIFF
--- a/routes/admin.js
+++ b/routes/admin.js
@@ -27,4 +27,9 @@ router.post("/pedidos/:id/estado", adminController.cambiarEstado)
  */
 router.post("/pedidos/:id/pago", adminController.cambiarEstadoPago)
 
+/**
+ * Eliminar un pedido
+ */
+router.post("/pedidos/:id/eliminar", adminController.eliminar) // Borra el pedido y sus detalles
+
 module.exports = router

--- a/views/admin/pedidos.ejs
+++ b/views/admin/pedidos.ejs
@@ -22,6 +22,11 @@
                 <i class="bi bi-check-circle"></i> Estado de pago actualizado correctamente.
                 <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
             </div>
+        <% } else if (query.success === 'eliminado') { %>
+            <div class="alert alert-success alert-dismissible fade show" role="alert">
+                <i class="bi bi-check-circle"></i> Pedido eliminado correctamente.
+                <button type="button" class="btn-close" data-bs-dismiss="alert"></button>
+            </div>
         <% } else if (query.error) { %>
             <div class="alert alert-danger alert-dismissible fade show" role="alert">
                 <i class="bi bi-exclamation-triangle"></i> Error al actualizar. Inténtalo de nuevo.
@@ -86,13 +91,16 @@
                                         </small>
                                     </td>
                                     <td class="d-flex gap-1">
-                                        <button class="btn btn-outline-primary btn-sm" onclick="alert('Ver detalles - Funcionalidad pendiente')">
-                                            <i class="bi bi-eye"></i>
-                                        </button>
                                         <form action="/admin/pedidos/<%= pedido.id %>/estado" method="POST" onsubmit="return confirm('¿Anular pedido?');">
                                             <input type="hidden" name="estado" value="cancelado">
                                             <button class="btn btn-outline-danger btn-sm" type="submit">
                                                 <i class="bi bi-x-circle"></i>
+                                            </button>
+                                        </form>
+                                        <!-- Borrar pedido de la base de datos -->
+                                        <form action="/admin/pedidos/<%= pedido.id %>/eliminar" method="POST" onsubmit="return confirm('¿Eliminar pedido definitivamente?');">
+                                            <button class="btn btn-danger btn-sm" type="submit">
+                                                <i class="bi bi-trash"></i>
                                             </button>
                                         </form>
                                     </td>

--- a/views/chat/chat.ejs
+++ b/views/chat/chat.ejs
@@ -142,10 +142,14 @@ function addMessageToChat(data) {
     const isOwnMessage = data.usuario === currentUser.nombre;
     const messageClass = isOwnMessage ? 'chat-message own' : 'chat-message other';
     
-    const timestamp = data.timestamp || new Date().toLocaleTimeString('es-ES', {
+    // Usar la marca de tiempo proporcionada o formatear la de la base de datos
+    const timestamp = data.timestamp || (data.fecha ? new Date(data.fecha).toLocaleTimeString('es-ES', {
         hour: '2-digit',
         minute: '2-digit'
-    });
+    }) : new Date().toLocaleTimeString('es-ES', {
+        hour: '2-digit',
+        minute: '2-digit'
+    }));
     
     messageDiv.innerHTML = `
         <div class="${messageClass}">

--- a/views/pedidos/detalle.ejs
+++ b/views/pedidos/detalle.ejs
@@ -1,3 +1,6 @@
+<%- include('../partials/head') %> <!-- Estructura básica y estilos -->
+<%- include('../partials/header') %> <!-- Barra de navegación principal -->
+
 <!-- 📋 Detalle de un pedido específico -->
 <div class="container py-4">
     <div class="row">
@@ -40,9 +43,11 @@
                             <p><strong><i class="bi bi-currency-euro"></i> Total:</strong> 
                                 <span class="text-primary fs-5">€<%= pedido.total.toFixed(2) %></span>
                             </p>
-                        </div>
-                    </div>
-                </div>
+</div>
+</div>
+</div>
+<%- include('../partials/footer') %>
+<%- include('../partials/footer') %>
             </div>
 
             <!-- Detalles de productos -->
@@ -112,3 +117,5 @@
         </div>
     </div>
 </div>
+
+<%- include("../partials/footer") %> <!-- Scripts y cierre de la página -->


### PR DESCRIPTION
## Summary
- unify payment status alias and show color correctly
- allow admins to delete orders from panel
- improve order details view with shared layout
- fix chat timestamp for stored messages
- remove unused button in admin orders

## Testing
- `npm test` *(fails: Missing script `test`)*

------
https://chatgpt.com/codex/tasks/task_e_6873e34c09ac832aba7d47153c9159e1