### PR TITLE
Fix status display and details alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,4 +179,6 @@ Este README resume de forma detallada la funcionalidad de cada carpeta y archivo
 - Se añadió ruta y controlador `verDetalle` para acceder a dicha vista.
 - La gestión de pedidos ahora muestra indicadores de color en los select de estado y pago y solo mantiene un botón de eliminación por pedido.
 - Correcciones en el cambio de estado de pedidos cancelados y mejora en las insignias de estado/pago del detalle para mostrar texto explicativo.
+- Se corrigió la vista de detalle para mostrar correctamente el estado y pago
+  alineando los colores con la gestión de pedidos.
 

--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -161,7 +161,11 @@ exports.verDetalle = async (req, res) => {
 
     const [pedido] = await db.query(
       `
-      SELECT p.*, u.nombre as cliente_nombre, u.email as cliente_email
+      SELECT
+        p.*, 
+        p.pago_estado AS estado_pago,
+        u.nombre as cliente_nombre,
+        u.email as cliente_email
       FROM pedidos p
       JOIN usuarios u ON p.usuario_id = u.id
       WHERE p.id = ?

--- a/controllers/pedidosController.js
+++ b/controllers/pedidosController.js
@@ -197,8 +197,9 @@ exports.verDetalle = async (req, res) => {
     // Obtener pedido con detalles
     const [pedido] = await db.query(
       `
-      SELECT 
-        p.*,
+      SELECT
+        p.*, 
+        p.pago_estado AS estado_pago,
         u.nombre as cliente_nombre,
         u.email as cliente_email
       FROM pedidos p

--- a/views/admin/pedido_detalle.ejs
+++ b/views/admin/pedido_detalle.ejs
@@ -10,7 +10,7 @@
                 <div class="card-header d-flex justify-content-between align-items-center">
                     <h3><i class="bi bi-receipt"></i> Pedido #<%= pedido.id %></h3>
                     <div>
-                        <span class="badge me-2 bg-<%= pedido.estado === 'terminado' ? 'success' : pedido.estado === 'en_proceso' ? 'info' : pedido.estado === 'entregado' ? 'primary' : pedido.estado === 'cancelado' ? 'danger' : 'warning' %>">
+                        <span class="badge me-2 bg-<%= pedido.estado === 'entregado' ? 'success' : pedido.estado === 'terminado' ? 'info' : pedido.estado === 'en_proceso' ? 'warning' : pedido.estado === 'cancelado' ? 'danger' : 'secondary' %>">
                           <strong>Estado:</strong>
                           <%= pedido.estado === 'en_proceso' ? 'En Proceso' : pedido.estado.charAt(0).toUpperCase() + pedido.estado.slice(1) %>
                         </span>

--- a/views/pedidos/detalle.ejs
+++ b/views/pedidos/detalle.ejs
@@ -16,7 +16,7 @@
                 <div class="card-header d-flex justify-content-between align-items-center">
                     <h3><i class="bi bi-receipt"></i> Pedido #<%= pedido.id %></h3>
                     <div>
-                        <span class="badge bg-<%= pedido.estado === 'terminado' ? 'success' : pedido.estado === 'en_proceso' ? 'info' : pedido.estado === 'entregado' ? 'primary' : pedido.estado === 'cancelado' ? 'danger' : 'warning' %> me-2">
+                        <span class="badge bg-<%= pedido.estado === 'entregado' ? 'success' : pedido.estado === 'terminado' ? 'info' : pedido.estado === 'en_proceso' ? 'warning' : pedido.estado === 'cancelado' ? 'danger' : 'secondary' %> me-2">
                           <%= pedido.estado === 'en_proceso' ? 'En Proceso' : pedido.estado.charAt(0).toUpperCase() + pedido.estado.slice(1) %>
                         </span>
                         <span class="badge bg-<%= pedido.estado_pago === 'Pagado' ? 'success' : pedido.estado_pago === 'Pagado parcial' ? 'warning' : 'danger' %>">


### PR DESCRIPTION
## Summary
- fix alias for `estado_pago` in admin and user order detail queries
- unify color display for order status badges
- correct badges in order detail views
- document bug fix in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687d85606784832a93626c0db34a44ba