### PR TITLE
Fix rate limit and dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,4 +219,9 @@ cualquier cliente en todo momento y muestra cuántos mensajes quedan pendientes 
   disponibles.
 - Los estados de los pedidos recientes en el dashboard muestran el texto y los
   colores coherentes con la gestión de pedidos.
+- Los intentos fallidos de autenticación devuelven ahora códigos de estado
+  adecuados para que el limitador de peticiones funcione correctamente.
+- Al cancelar un pedido se solicita confirmación con un mensaje más descriptivo.
+- El cálculo de ingresos en el dashboard considera los pedidos cuyo pago está
+  registrado como pagado o pagado parcial.
 

--- a/controllers/adminController.js
+++ b/controllers/adminController.js
@@ -12,7 +12,9 @@ exports.dashboard = async (req, res) => {
         (SELECT COUNT(*) FROM pedidos) as total_pedidos,
         (SELECT COUNT(*) FROM usuarios WHERE rol = 'cliente') as total_clientes,
         (SELECT COUNT(*) FROM productos) as total_productos,
-        (SELECT COALESCE(SUM(total), 0) FROM pedidos WHERE LOWER(TRIM(estado)) = 'entregado') as ingresos_totales
+        (SELECT COALESCE(SUM(total), 0)
+           FROM pedidos
+          WHERE LOWER(TRIM(pago_estado)) IN ('pagado', 'pagado parcial')) as ingresos_totales
     `)
 
     // Obtener pedidos recientes (ajustado a tu estructura de BD)

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -35,7 +35,7 @@ exports.procesarRegistro = async (req, res) => {
 
   // Si hay errores de validación, mostrar formulario con errores
   if (!errors.isEmpty()) {
-    return res.render("auth/register", {
+    return res.status(400).render("auth/register", {
       title: "Registro de Usuario",
       errors: errors.array(),
       oldData: req.body,
@@ -46,7 +46,7 @@ exports.procesarRegistro = async (req, res) => {
   // Validar contraseña de administrador si se intenta crear un admin
   if (rol === "admin") {
     if (!admin_password || admin_password !== "4dm1n") {
-      return res.render("auth/register", {
+      return res.status(401).render("auth/register", {
         title: "Registro de Usuario",
         errors: [{ msg: "Contraseña de administrador incorrecta" }],
         oldData: req.body,
@@ -60,7 +60,7 @@ exports.procesarRegistro = async (req, res) => {
     const [existingUser] = await db.query("SELECT id FROM usuarios WHERE email = ?", [email])
 
     if (existingUser.length > 0) {
-      return res.render("auth/register", {
+      return res.status(400).render("auth/register", {
         title: "Registro de Usuario",
         errors: [{ msg: "Este email ya está registrado" }],
         oldData: req.body,
@@ -83,7 +83,7 @@ exports.procesarRegistro = async (req, res) => {
     res.redirect("/auth/login?registered=true")
   } catch (error) {
     console.error("❌ Error en registro:", error)
-    res.render("auth/register", {
+    res.status(500).render("auth/register", {
       title: "Registro de Usuario",
       errors: [{ msg: "Error interno del servidor" }],
       oldData: req.body,
@@ -101,7 +101,7 @@ exports.procesarLogin = async (req, res) => {
 
   // Si hay errores de validación
   if (!errors.isEmpty()) {
-    return res.render("auth/login", {
+    return res.status(400).render("auth/login", {
       title: "Iniciar Sesión",
       errors: errors.array(),
       oldData: req.body,
@@ -115,7 +115,7 @@ exports.procesarLogin = async (req, res) => {
 
     // Verificar si existe el usuario y la contraseña es correcta
     if (usuarios.length === 0 || !(await bcrypt.compare(password, usuarios[0].password))) {
-      return res.render("auth/login", {
+      return res.status(401).render("auth/login", {
         title: "Iniciar Sesión",
         errors: [{ msg: "Email o contraseña incorrectos" }],
         oldData: { email },
@@ -137,7 +137,7 @@ exports.procesarLogin = async (req, res) => {
     res.redirect(redirectTo)
   } catch (error) {
     console.error("❌ Error en login:", error)
-    res.render("auth/login", {
+    res.status(500).render("auth/login", {
       title: "Iniciar Sesión",
       errors: [{ msg: "Error interno del servidor" }],
       oldData: { email },

--- a/views/pedidos/detalle.ejs
+++ b/views/pedidos/detalle.ejs
@@ -105,7 +105,7 @@
                     <i class="bi bi-arrow-left"></i> Volver a Mis Pedidos
                 </a>
                 <% if (pedido.estado === 'recibido' || pedido.estado === 'pendiente') { %>
-                    <form action="/pedidos/<%= pedido.id %>/cancelar" method="POST" class="d-inline" onsubmit="return confirm('¿Cancelar pedido?');">
+                    <form action="/pedidos/<%= pedido.id %>/cancelar" method="POST" class="d-inline" onsubmit="return confirm('¿Está seguro de que desea cancelar este pedido?');">
                         <button class="btn btn-warning">
                             <i class="bi bi-x-circle"></i> Cancelar Pedido
                         </button>


### PR DESCRIPTION
## Summary
- improve rate limiter effectiveness by setting HTTP status codes on failed login and registration
- compute dashboard revenue using paid orders
- clarify order cancel confirmation message
- document recent changes in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run lint` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_687fbd194bac832a8ced95c68ce18cec