### PR TITLE
Fix unread chat count and dashboard status badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,4 +224,8 @@ cualquier cliente en todo momento y muestra cuántos mensajes quedan pendientes 
 - Al cancelar un pedido se solicita confirmación con un mensaje más descriptivo.
 - El cálculo de ingresos en el dashboard considera los pedidos cuyo pago está
   registrado como pagado o pagado parcial.
+- Al iniciar sesión se marca como leída la conversación de soporte para que el
+  contador de mensajes muestre únicamente los nuevos.
+- Se ajustó la insignia de estado en los pedidos recientes del dashboard para
+  usar el mismo formato que en la gestión de pedidos.
 

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -128,6 +128,19 @@ exports.procesarLogin = async (req, res) => {
     delete usuario.password
     req.session.usuario = usuario
 
+    if (usuario.rol === "cliente") {
+      try {
+        const [maxRow] = await db.query(
+          "SELECT MAX(id) AS lastId FROM mensajes_soporte WHERE usuario_id = ? AND emisor_rol = 'admin'",
+          [usuario.id],
+        )
+        req.session.ultimaLecturaSoporte = maxRow[0].lastId || 0
+      } catch (e) {
+        console.error("❌ Error obteniendo última lectura de soporte:", e)
+        req.session.ultimaLecturaSoporte = 0
+      }
+    }
+
     console.log(`✅ Usuario logueado: ${email} (${usuario.rol})`)
 
     // Redirigir a la página que intentaba acceder o al dashboard

--- a/views/admin/dashboard.ejs
+++ b/views/admin/dashboard.ejs
@@ -181,10 +181,10 @@
                                             <td class="fw-bold text-primary">€<%= Number(pedido.total).toFixed(2) %></td>
                                             <td>
                                                 <span class="badge <%= pedido.estado === 'entregado' ? 'bg-success text-white' : pedido.estado === 'terminado' ? 'bg-info text-white' : pedido.estado === 'en_proceso' ? 'bg-warning text-dark' : pedido.estado === 'cancelado' ? 'bg-cancelado text-white' : 'bg-secondary text-white' %>">
-                                                    <%= pedido.estado
-                                                        ? (pedido.estado === 'en_proceso'
-                                                            ? 'En Proceso'
-                                                            : pedido.estado.replace('_', ' ').charAt(0).toUpperCase() + pedido.estado.replace('_', ' ').slice(1))
+                                                    <%= pedido.estado === 'en_proceso'
+                                                        ? 'En Proceso'
+                                                        : pedido.estado
+                                                        ? pedido.estado.charAt(0).toUpperCase() + pedido.estado.slice(1)
                                                         : 'Sin estado' %>
                                                 </span>
                                             </td>


### PR DESCRIPTION
## Summary
- set last support message id on login so unread count works
- align dashboard status badge text and colors with order management
- document the changes in README

## Testing
- `npm start` *(fails: Error conectando a MySQL)*

------
https://chatgpt.com/codex/tasks/task_e_687fca9b07fc832ab675793cf5fade8a