### PR TITLE
Fix support badge persistence and dashboard colors

### DIFF
--- a/README.md
+++ b/README.md
@@ -224,12 +224,15 @@ cualquier cliente en todo momento y muestra cuántos mensajes quedan pendientes 
 - Al cancelar un pedido se solicita confirmación con un mensaje más descriptivo.
 - El cálculo de ingresos en el dashboard considera los pedidos cuyo pago está
   registrado como pagado o pagado parcial.
-- Al iniciar sesión se marca como leída la conversación de soporte para que el
-  contador de mensajes muestre únicamente los nuevos.
+- El indicador de soporte mantiene los mensajes pendientes entre sesiones usando
+  una cookie `ultimaLecturaSoporte`. Ya no se marcan como leídos al iniciar
+  sesión automáticamente.
 - Se ajustó la insignia de estado en los pedidos recientes del dashboard para
   usar el mismo formato que en la gestión de pedidos.
 - La insignia del chat vuelve a mostrar cuántos mensajes de soporte quedan por
   leer y se actualiza automáticamente al recibirlos.
 - Se corrige la columna de estado de los pedidos recientes en el dashboard para
   garantizar que siempre muestre texto y colores coherentes.
+- El contador de mensajes sin leer en el menú ahora se conserva tras cerrar
+  sesión y volver a entrar.
 

--- a/app.js
+++ b/app.js
@@ -51,7 +51,8 @@ app.use(async (req, res, next) => {
   if (req.session.usuario && req.session.usuario.rol === 'cliente') {
     try {
       const userId = req.session.usuario.id
-      const lastRead = req.session.ultimaLecturaSoporte || 0
+      const cookieRead = parseInt(req.cookies.ultimaLecturaSoporte, 10)
+      const lastRead = req.session.ultimaLecturaSoporte || (isNaN(cookieRead) ? 0 : cookieRead)
       const [rows] = await db.query(
         `SELECT COUNT(*) AS sin_leer
            FROM mensajes_soporte

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -129,16 +129,10 @@ exports.procesarLogin = async (req, res) => {
     req.session.usuario = usuario
 
     if (usuario.rol === "cliente") {
-      try {
-        const [maxRow] = await db.query(
-          "SELECT MAX(id) AS lastId FROM mensajes_soporte WHERE usuario_id = ? AND emisor_rol = 'admin'",
-          [usuario.id],
-        )
-        req.session.ultimaLecturaSoporte = maxRow[0].lastId || 0
-      } catch (e) {
-        console.error("❌ Error obteniendo última lectura de soporte:", e)
-        req.session.ultimaLecturaSoporte = 0
-      }
+      // Usar la información almacenada en la cookie para mantener las
+      // conversaciones pendientes entre sesiones
+      const ultima = parseInt(req.cookies.ultimaLecturaSoporte, 10)
+      req.session.ultimaLecturaSoporte = isNaN(ultima) ? 0 : ultima
     }
 
     console.log(`✅ Usuario logueado: ${email} (${usuario.rol})`)

--- a/routes/api.js
+++ b/routes/api.js
@@ -51,7 +51,9 @@ router.post("/mensajes/leido", async (req, res) => {
       "SELECT MAX(id) AS lastId FROM mensajes_soporte WHERE usuario_id = ?",
       [userId],
     )
-    req.session.ultimaLecturaSoporte = row[0].lastId || req.session.ultimaLecturaSoporte || 0
+    const lastId = row[0].lastId || req.session.ultimaLecturaSoporte || 0
+    req.session.ultimaLecturaSoporte = lastId
+    res.cookie("ultimaLecturaSoporte", lastId, { maxAge: 31536000000 })
     res.json({ success: true })
   } catch (err) {
     console.error("❌ Error marcando mensajes como leídos:", err)

--- a/routes/chat.js
+++ b/routes/chat.js
@@ -35,7 +35,9 @@ router.get("/", requireAuth, async (req, res) => {
       "SELECT MAX(id) AS lastId FROM mensajes_soporte WHERE usuario_id = ?",
       [req.session.usuario.id],
     )
-    req.session.ultimaLecturaSoporte = maxRow[0].lastId || 0
+    const lastId = maxRow[0].lastId || 0
+    req.session.ultimaLecturaSoporte = lastId
+    res.cookie("ultimaLecturaSoporte", lastId, { maxAge: 31536000000 })
   } catch (err) {
     console.error("❌ Error obteniendo última lectura de soporte:", err)
   }

--- a/views/admin/dashboard.ejs
+++ b/views/admin/dashboard.ejs
@@ -180,7 +180,7 @@
                                             </td>
                                             <td class="fw-bold text-primary">€<%= Number(pedido.total).toFixed(2) %></td>
                                             <td>
-                                                <span class="badge <%= pedido.estado === 'entregado' ? 'bg-success text-white' : pedido.estado === 'terminado' ? 'bg-info text-white' : pedido.estado === 'en_proceso' ? 'bg-warning text-dark' : pedido.estado === 'cancelado' ? 'bg-cancelado text-white' : 'bg-secondary text-white' %>">
+                                                <span class="badge <%= pedido.estado === 'entregado' ? 'bg-success text-white' : pedido.estado === 'terminado' ? 'bg-info text-white' : pedido.estado === 'en_proceso' ? 'bg-warning' : pedido.estado === 'cancelado' ? 'bg-cancelado text-white' : 'bg-secondary text-white' %>">
                                                     <%= pedido.estado === 'en_proceso'
                                                         ? 'En Proceso'
                                                         : pedido.estado


### PR DESCRIPTION
## Summary
- persist chat message counter across sessions using cookie
- remove login reset of support counter
- update API and chat routes to update cookie
- align dashboard status badge colors with order management
- document changes in README

## Testing
- `node --check app.js`
- `node --check controllers/authController.js`
- `node --check routes/chat.js`
- `node --check routes/api.js`


------
https://chatgpt.com/codex/tasks/task_e_687fda900cec832ab7da33ab13bf67be