### PR TITLE
Fix per-user chat read tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,4 +242,6 @@ cualquier cliente en todo momento y muestra cuántos mensajes quedan pendientes 
   contabilice los nuevos.
 - La lectura de mensajes de soporte se registra ahora tras cargar el chat en el
   cliente, evitando desajustes en el contador de pendientes.
+- La cookie que guarda la última lectura de soporte se diferencia ahora por
+  usuario, de modo que cada cuenta mantiene sus propios mensajes pendientes.
 

--- a/app.js
+++ b/app.js
@@ -54,7 +54,8 @@ app.use(async (req, res, next) => {
   if (req.session.usuario && req.session.usuario.rol === 'cliente') {
     try {
       const userId = req.session.usuario.id
-      const cookieRead = parseInt(req.cookies.ultimaLecturaSoporte, 10)
+      const cookieName = `ultimaLecturaSoporte_${userId}`
+      const cookieRead = parseInt(req.cookies[cookieName], 10)
       const lastRead = req.session.ultimaLecturaSoporte || (isNaN(cookieRead) ? 0 : cookieRead)
       const [rows] = await db.query(
         `SELECT COUNT(*) AS sin_leer

--- a/controllers/authController.js
+++ b/controllers/authController.js
@@ -129,12 +129,13 @@ exports.procesarLogin = async (req, res) => {
     req.session.usuario = usuario
 
     if (usuario.rol === "cliente") {
-      // Mantener la última lectura de soporte usando la cookie.
+      // Mantener la última lectura de soporte usando una cookie por usuario.
       // Si no existe, comenzamos desde cero para contar todos los mensajes.
-      const ultima = parseInt(req.cookies.ultimaLecturaSoporte, 10)
+      const cookieName = `ultimaLecturaSoporte_${usuario.id}`
+      const ultima = parseInt(req.cookies[cookieName], 10)
       if (isNaN(ultima)) {
         req.session.ultimaLecturaSoporte = 0
-        res.cookie("ultimaLecturaSoporte", 0, { maxAge: 31536000000 })
+        res.cookie(cookieName, 0, { maxAge: 31536000000 })
       } else {
         req.session.ultimaLecturaSoporte = ultima
       }

--- a/routes/api.js
+++ b/routes/api.js
@@ -53,7 +53,8 @@ router.post("/mensajes/leido", async (req, res) => {
     )
     const lastId = row[0].lastId || req.session.ultimaLecturaSoporte || 0
     req.session.ultimaLecturaSoporte = lastId
-    res.cookie("ultimaLecturaSoporte", lastId, { maxAge: 31536000000 })
+    const cookieName = `ultimaLecturaSoporte_${userId}`
+    res.cookie(cookieName, lastId, { maxAge: 31536000000 })
     res.json({ success: true })
   } catch (err) {
     console.error("❌ Error marcando mensajes como leídos:", err)


### PR DESCRIPTION
## Summary
- keep chat read status by user using unique cookie names
- document per-user cookie change in README

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_688277d5d708832aa10f4dc6d39cf786